### PR TITLE
Watchdog based reloader

### DIFF
--- a/gunicorn/_reloader.py
+++ b/gunicorn/_reloader.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+import os.path
+import re
+import sys
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+
+class Reloader(object):
+
+    def __init__(self, extra_files=None, interval=1, callback=None,
+                 engine='auto'):
+        super(Reloader, self).__init__()
+        if engine == 'auto' or engine == 'inotify':
+            self._observer = Observer()
+        else:
+            assert engine == 'poll'
+            self._observer = PollingObserver(timeout=interval)
+        self._observer.daemon = True
+        self._handler = ReloadingEventHandler(callback)
+        self._dirs = set()
+
+        if extra_files is not None:
+            for filename in extra_files:
+                self.add_extra_file(filename)
+
+    def add_extra_file(self, filename):
+        dirname = os.path.dirname(filename)
+        self._observer.schedule(self._handler, dirname)
+
+    def get_dirs(self):
+        fnames = [
+            os.path.dirname(re.sub('py[co]$', 'py', module.__file__))
+            for module in list(sys.modules.values())
+            if hasattr(module, '__file__')
+        ]
+
+        return set(fnames)
+
+    def start(self):
+        for dirname in self.get_dirs():
+            self._observer.schedule(self._handler, dirname)
+
+        self._observer.start()
+
+
+class ReloadingEventHandler(FileSystemEventHandler):
+    def __init__(self, callback=None):
+        super(ReloadingEventHandler, self).__init__()
+        self._callback = callback
+
+    def on_any_event(self, _event):
+        self._callback(_event.src_path)

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -844,12 +844,8 @@ class Reload(Setting):
         paste configuration be sure that the server block does not import any
         application code or the reload will not work as designed.
 
-        The default behavior is to attempt inotify with a fallback to file
-        system polling. Generally, inotify should be preferred if available
-        because it consumes less system resources.
-
         .. note::
-           In order to use the inotify reloader, you must have the ``inotify``
+           In order to use the reloader, you must have the ``watchdog``
            package installed.
         '''
 
@@ -868,9 +864,13 @@ class ReloadEngine(Setting):
 
         * 'auto'
         * 'poll'
-        * 'inotify' (requires inotify)
+        * 'inotify'
 
         .. versionadded:: 19.7
+
+        .. versionchanged:: 19.8
+           A value of 'inotify' is an alias for 'auto' and uses the
+           best implementation available on the platform.
         """
 
 

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -3,128 +3,15 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-import os
-import os.path
-import re
-import sys
-import time
-import threading
+__all__ = ['Reloader', 'reloader_engines']
 
+try:
+    from gunicorn._reloader import Reloader
+except ImportError:
+    class Reloader(object):
+        def __init__(self, *args, **kwargs):
+            raise ImportError('You must have the watchdog module '
+                              'installed to use the reloader')
 
-class Reloader(threading.Thread):
-    def __init__(self, extra_files=None, interval=1, callback=None):
-        super(Reloader, self).__init__()
-        self.setDaemon(True)
-        self._extra_files = set(extra_files or ())
-        self._extra_files_lock = threading.RLock()
-        self._interval = interval
-        self._callback = callback
-
-    def add_extra_file(self, filename):
-        with self._extra_files_lock:
-            self._extra_files.add(filename)
-
-    def get_files(self):
-        fnames = [
-            re.sub('py[co]$', 'py', module.__file__)
-            for module in list(sys.modules.values())
-            if hasattr(module, '__file__')
-        ]
-
-        with self._extra_files_lock:
-            fnames.extend(self._extra_files)
-
-        return fnames
-
-    def run(self):
-        mtimes = {}
-        while True:
-            for filename in self.get_files():
-                try:
-                    mtime = os.stat(filename).st_mtime
-                except OSError:
-                    continue
-                old_time = mtimes.get(filename)
-                if old_time is None:
-                    mtimes[filename] = mtime
-                    continue
-                elif mtime > old_time:
-                    if self._callback:
-                        self._callback(filename)
-            time.sleep(self._interval)
-
-has_inotify = False
-if sys.platform.startswith('linux'):
-    try:
-        from inotify.adapters import Inotify
-        import inotify.constants
-        has_inotify = True
-    except ImportError:
-        pass
-
-
-if has_inotify:
-
-    class InotifyReloader(threading.Thread):
-        event_mask = (inotify.constants.IN_CREATE | inotify.constants.IN_DELETE
-                      | inotify.constants.IN_DELETE_SELF | inotify.constants.IN_MODIFY
-                      | inotify.constants.IN_MOVE_SELF | inotify.constants.IN_MOVED_FROM
-                      | inotify.constants.IN_MOVED_TO)
-
-        def __init__(self, extra_files=None, callback=None):
-            super(InotifyReloader, self).__init__()
-            self.setDaemon(True)
-            self._callback = callback
-            self._dirs = set()
-            self._watcher = Inotify()
-
-            for extra_file in extra_files:
-                self.add_extra_file(extra_file)
-
-        def add_extra_file(self, filename):
-            dirname = os.path.dirname(filename)
-
-            if dirname in self._dirs:
-                return
-
-            self._watcher.add_watch(dirname, mask=self.event_mask)
-            self._dirs.add(dirname)
-
-        def get_dirs(self):
-            fnames = [
-                os.path.dirname(re.sub('py[co]$', 'py', module.__file__))
-                for module in list(sys.modules.values())
-                if hasattr(module, '__file__')
-            ]
-
-            return set(fnames)
-
-        def run(self):
-            self._dirs = self.get_dirs()
-
-            for dirname in self._dirs:
-                self._watcher.add_watch(dirname, mask=self.event_mask)
-
-            for event in self._watcher.event_gen():
-                if event is None:
-                    continue
-
-                filename = event[3]
-
-                self._callback(filename)
-
-else:
-
-    class InotifyReloader(object):
-        def __init__(self, callback=None):
-            raise ImportError('You must have the inotify module installed to '
-                              'use the inotify reloader')
-
-
-preferred_reloader = InotifyReloader if has_inotify else Reloader
-
-reloader_engines = {
-    'auto': preferred_reloader,
-    'poll': Reloader,
-    'inotify': InotifyReloader,
-}
+# Note: inotify is an alias for 'auto'
+reloader_engines = ('auto', 'poll', 'inotify')


### PR DESCRIPTION
Replace the reloader with a reloader based on the watchdog package.
This new reloader should work on all the platforms. Most popular
platforms use an underlying event system like inotify or kqueue, but
watchdog will fall back to a polling implementation.

Start the reloader after loading the WSGI entry point of the application
so that the reloader picks up the application code modules when scanning
sys.modules and have the worker send SIGQUIT to itself in its callback
because that seems to make exits happen more quickly, which is more in
line with the common development use case for reloading.